### PR TITLE
finaliza a sessao local caso a sessão da api não autorize mais acesso

### DIFF
--- a/influunt-app/app/scripts/config.js
+++ b/influunt-app/app/scripts/config.js
@@ -492,7 +492,6 @@ angular
 
         $rootScope.$on('$stateChangeStart', function(ev, toState) {
           $timeout(function() {
-            console.log(toState.name);
             if (!$rootScope.isAuthenticated() && toState.name !== 'login') {
                 $state.go('login');
             }

--- a/influunt-app/app/scripts/config.js
+++ b/influunt-app/app/scripts/config.js
@@ -492,6 +492,7 @@ angular
 
         $rootScope.$on('$stateChangeStart', function(ev, toState) {
           $timeout(function() {
+            console.log(toState.name);
             if (!$rootScope.isAuthenticated() && toState.name !== 'login') {
                 $state.go('login');
             }

--- a/influunt-app/app/scripts/services/auth-interceptor.js
+++ b/influunt-app/app/scripts/services/auth-interceptor.js
@@ -28,6 +28,12 @@ angular.module('influuntApp')
             toast.warn('Ação não autorizada');
           }
 
+          if (response.status === 401) {
+            location.hash = '#/login';
+            localStorage.removeItem('token');
+            toast.warn('Ação não autorizada');
+          }
+
           return $q.reject(response);
         },
         response: function(response) {


### PR DESCRIPTION
Corrige problema que ocorre quando uma sessão de login não é finalizada localmente mas é pela API. O app permitia acesso ao usuário às telas não autorizadas.