### PR TITLE
Checar alteração de dados do controlador

### DIFF
--- a/influunt-api/app/json/ControladorCustomDeserializer.java
+++ b/influunt-api/app/json/ControladorCustomDeserializer.java
@@ -580,6 +580,9 @@ public class ControladorCustomDeserializer {
         if (node.has("descricao")) {
             detector.setDescricao(node.get("descricao").asText());
         }
+        if (node.has("monitorado")) {
+            detector.setMonitorado(node.get("monitorado").asBoolean());
+        }
         if (node.has("tempoAusenciaDeteccaoMinima")) {
             detector.setTempoAusenciaDeteccaoMinima(node.get("tempoAusenciaDeteccaoMinima").asInt());
         }


### PR DESCRIPTION
Esse PR é referente à issue #489. O campo `monitorado` do model `Detector` não estava no deserializer, e não era atualizado.