### PR TITLE
582 mensagem de limite de detectores

### DIFF
--- a/influunt-app/app/json/i18n-pt-br.json
+++ b/influunt-app/app/json/i18n-pt-br.json
@@ -81,6 +81,7 @@
             "adicionarDetector": "Adicionar Detector",
             "detector": "detector",
             "titulo": "Detectores",
+            "mensagemMaxDetectores": "Você poderá adicionar até",
             "verTabelaEntreVerdes": "Ver Tela de Entre Verdes"
         },
         "dadosBasicos": {

--- a/influunt-app/app/styles/influunt.css
+++ b/influunt-app/app/styles/influunt.css
@@ -92,9 +92,13 @@
   color: #f7f7f7;
 }
 
-.wrapper-content .basic-wizard .content .body .tableless table td {
+.wrapper-content .basic-wizard .content .body .tableless table > td {
   text-align: center;
   font-size: 25px;
+}
+
+.wrapper-content .basic-wizard .content .body .tableless table td p {
+  clear: both;
 }
 
 .wrapper-content .basic-wizard .content .body .tableless table tbody tr td.checked {

--- a/influunt-app/app/styles/influunt.scss
+++ b/influunt-app/app/styles/influunt.scss
@@ -84,9 +84,12 @@
     transition: all .5s ease;
     color: #f7f7f7;
 }
-.wrapper-content .basic-wizard .content .body .tableless table td {
+.wrapper-content .basic-wizard .content .body .tableless table > td {
     text-align: center;
     font-size: 25px;
+}
+.wrapper-content .basic-wizard .content .body .tableless table td p {
+    clear: both;
 }
 .wrapper-content .basic-wizard .content .body .tableless table tbody tr td.checked {
     background: #e5e5e5;

--- a/influunt-app/app/views/controladores/wizard/associacao-detectores.html
+++ b/influunt-app/app/views/controladores/wizard/associacao-detectores.html
@@ -91,6 +91,7 @@
                                 <a>Veicular</a>
                               </li>
                             </ul>
+                            <p class="both">{{ 'controladores.associacaoDetectores.mensagemMaxDetectores' | translate }} {{ currentEstagios.length }} {{ 'controladores.associacaoDetectores.titulo' | translate }}</p>
                           </div>
                         </td>
                       </tr>


### PR DESCRIPTION
Sugestão: Ao invés do tooltip, coloquei a informação da quantidade máxima de detectores a serem colocados, assim evita a surpresa quando trava o botão.