### PR TITLE
Estava faltando setar a subarea na hora de copiar o controlador

### DIFF
--- a/influunt-api/app/helpers/ControladorUtil.java
+++ b/influunt-api/app/helpers/ControladorUtil.java
@@ -42,6 +42,7 @@ public class ControladorUtil {
         controladorClone.setStatusControlador(StatusControlador.EM_EDICAO);
         controladorClone.setArea(controlador.getArea());
         controladorClone.setModelo(controlador.getModelo());
+        controladorClone.setSubarea(controlador.getSubarea());
 
         if (controlador.getEndereco() != null && controlador.getEndereco().getIdJson() != null) {
             Endereco enderecoAux = copyPrimitveFields(controlador.getEndereco());

--- a/influunt-api/conf/evolutions/default/1.sql
+++ b/influunt-api/conf/evolutions/default/1.sql
@@ -4,70 +4,70 @@
 # --- !Ups
 
 create table agrupamentos (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   nome                          varchar(255),
   numero                        varchar(255),
   tipo                          varchar(8),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint ck_agrupamentos_tipo check (tipo in ('ROTA','CORREDOR')),
   constraint pk_agrupamentos primary key (id)
 );
 
 create table agrupamentos_controladores (
-  agrupamento_id                varchar(40) not null,
-  controlador_id                varchar(40) not null,
+  agrupamento_id                uuid not null,
+  controlador_id                uuid not null,
   constraint pk_agrupamentos_controladores primary key (agrupamento_id,controlador_id)
 );
 
 create table aneis (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  ativo                         tinyint(1) default 0 not null,
+  ativo                         boolean not null,
   descricao                     varchar(255),
   posicao                       integer,
   numero_smee                   varchar(255),
-  controlador_id                varchar(40),
-  croqui_id                     varchar(40),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  controlador_id                uuid,
+  croqui_id                     uuid,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint uq_aneis_croqui_id unique (croqui_id),
   constraint pk_aneis primary key (id)
 );
 
 create table areas (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   descricao                     integer not null,
-  cidade_id                     varchar(40) not null,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  cidade_id                     uuid not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_areas primary key (id)
 );
 
 create table atrasos_de_grupos (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  transicao_id                  varchar(40),
+  transicao_id                  uuid,
   atraso_de_grupo               integer not null,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint uq_atrasos_de_grupos_transicao_id unique (transicao_id),
   constraint pk_atrasos_de_grupos primary key (id)
 );
 
 create table cidades (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   nome                          varchar(255),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_cidades primary key (id)
 );
 
 create table controladores (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   nome_endereco                 varchar(255) not null,
   status_controlador            integer,
@@ -77,185 +77,185 @@ create table controladores (
   numero_smeeconjugado2         varchar(255),
   numero_smeeconjugado3         varchar(255),
   firmware                      varchar(255),
-  modelo_id                     varchar(40) not null,
-  area_id                       varchar(40) not null,
-  subarea_id                    varchar(40),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  modelo_id                     uuid not null,
+  area_id                       uuid not null,
+  subarea_id                    uuid,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint ck_controladores_status_controlador check (status_controlador in (0,1,2,3)),
   constraint pk_controladores primary key (id)
 );
 
 create table controladores_fisicos (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_controladores_fisicos primary key (id)
 );
 
 create table detectores (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   tipo                          varchar(8),
-  anel_id                       varchar(40),
-  estagio_id                    varchar(40),
-  controlador_id                varchar(40),
+  anel_id                       uuid,
+  estagio_id                    uuid,
+  controlador_id                uuid,
   posicao                       integer,
   descricao                     varchar(255),
-  monitorado                    tinyint(1) default 0,
+  monitorado                    boolean,
   tempo_ausencia_deteccao       integer,
   tempo_deteccao_permanente     integer,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint ck_detectores_tipo check (tipo in ('VEICULAR','PEDESTRE')),
   constraint uq_detectores_estagio_id unique (estagio_id),
   constraint pk_detectores primary key (id)
 );
 
 create table enderecos (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  controlador_id                varchar(40),
-  anel_id                       varchar(40),
+  controlador_id                uuid,
+  anel_id                       uuid,
   localizacao                   varchar(255),
   latitude                      double not null,
   longitude                     double not null,
   localizacao2                  varchar(255),
   altura_numerica               integer,
   referencia                    varchar(255),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint uq_enderecos_controlador_id unique (controlador_id),
   constraint uq_enderecos_anel_id unique (anel_id),
   constraint pk_enderecos primary key (id)
 );
 
 create table estagios (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  imagem_id                     varchar(40),
+  imagem_id                     uuid,
   descricao                     varchar(255),
   tempo_maximo_permanencia      integer,
-  tempo_maximo_permanencia_ativado tinyint(1) default 0,
+  tempo_maximo_permanencia_ativado boolean,
   posicao                       integer,
-  demanda_prioritaria           tinyint(1) default 0,
-  anel_id                       varchar(40),
-  controlador_id                varchar(40),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  demanda_prioritaria           boolean,
+  anel_id                       uuid,
+  controlador_id                uuid,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint uq_estagios_imagem_id unique (imagem_id),
   constraint pk_estagios primary key (id)
 );
 
 create table estagios_grupos_semaforicos (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  estagio_id                    varchar(40) not null,
-  grupo_semaforico_id           varchar(40) not null,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  estagio_id                    uuid not null,
+  grupo_semaforico_id           uuid not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_estagios_grupos_semaforicos primary key (id)
 );
 
 create table estagios_planos (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  estagio_id                    varchar(40) not null,
-  plano_id                      varchar(40) not null,
+  estagio_id                    uuid not null,
+  plano_id                      uuid not null,
   posicao                       integer,
   tempo_verde                   integer,
   tempo_verde_minimo            integer,
   tempo_verde_maximo            integer,
   tempo_verde_intermediario     integer,
   tempo_extensao_verde          double,
-  dispensavel                   tinyint(1) default 0,
-  estagio_que_recebe_estagio_dispensavel_id varchar(40),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  dispensavel                   boolean,
+  estagio_que_recebe_estagio_dispensavel_id uuid,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_estagios_planos primary key (id)
 );
 
 create table eventos (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   posicao                       integer not null,
   dia_da_semana                 varchar(16),
   horario                       time not null,
-  data                          datetime(6),
+  data                          timestamp,
   nome                          varchar(255),
   posicao_plano                 integer not null,
   tipo                          varchar(23) not null,
-  tabela_horario_id             varchar(40) not null,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  tabela_horario_id             uuid not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint ck_eventos_dia_da_semana check (dia_da_semana in ('SEGUNDA_A_SEXTA','SEGUNDA_A_SABADO','SABADO_A_DOMINGO','TODOS_OS_DIAS','SEGUNDA','TERCA','QUARTA','QUINTA','SEXTA','SABADO','DOMINGO')),
   constraint ck_eventos_tipo check (tipo in ('NORMAL','ESPECIAL_RECORRENTE','ESPECIAL_NAO_RECORRENTE')),
   constraint pk_eventos primary key (id)
 );
 
 create table fabricantes (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   nome                          varchar(255) not null,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_fabricantes primary key (id)
 );
 
 create table grupos_semaforicos (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   tipo                          varchar(8),
   descricao                     varchar(255),
-  anel_id                       varchar(40),
-  controlador_id                varchar(40),
+  anel_id                       uuid,
+  controlador_id                uuid,
   posicao                       integer,
-  fase_vermelha_apagada_amarelo_intermitente tinyint(1) default 0,
+  fase_vermelha_apagada_amarelo_intermitente boolean,
   tempo_verde_seguranca         integer,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint ck_grupos_semaforicos_tipo check (tipo in ('PEDESTRE','VEICULAR')),
   constraint pk_grupos_semaforicos primary key (id)
 );
 
 create table grupos_semaforicos_planos (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  grupo_semaforico_id           varchar(40) not null,
-  plano_id                      varchar(40) not null,
-  ativado                       tinyint(1) default 0,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  grupo_semaforico_id           uuid not null,
+  plano_id                      uuid not null,
+  ativado                       boolean,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_grupos_semaforicos_planos primary key (id)
 );
 
 create table imagens (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   filename                      varchar(255),
   content_type                  varchar(255),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_imagens primary key (id)
 );
 
 create table limite_area (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   latitude                      double,
   longitude                     double,
   posicao                       integer,
-  area_id                       varchar(40),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  area_id                       uuid,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_limite_area primary key (id)
 );
 
 create table modelo_controladores (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  fabricante_id                 varchar(40) not null,
+  fabricante_id                 uuid not null,
   descricao                     varchar(255) not null,
   limite_estagio                integer not null,
   limite_grupo_semaforico       integer not null,
@@ -264,169 +264,169 @@ create table modelo_controladores (
   limite_detector_veicular      integer not null,
   limite_tabelas_entre_verdes   integer not null,
   limite_planos                 integer not null,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_modelo_controladores primary key (id)
 );
 
 create table perfis (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   nome                          varchar(255),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_perfis primary key (id)
 );
 
 create table permissoes_perfis (
-  perfil_id                     varchar(40) not null,
-  permissao_id                  varchar(40) not null,
+  perfil_id                     uuid not null,
+  permissao_id                  uuid not null,
   constraint pk_permissoes_perfis primary key (perfil_id,permissao_id)
 );
 
 create table permissoes (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   descricao                     varchar(255),
   chave                         varchar(255),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_permissoes primary key (id)
 );
 
 create table planos (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   posicao                       integer not null,
   descricao                     varchar(255) not null,
   tempo_ciclo                   integer,
   defasagem                     integer,
-  versao_plano_id               varchar(40) not null,
-  agrupamento_id                varchar(40),
+  versao_plano_id               uuid not null,
+  agrupamento_id                uuid,
   modo_operacao                 integer not null,
   posicao_tabela_entre_verde    integer not null,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint ck_planos_modo_operacao check (modo_operacao in (0,1,2,3,4)),
   constraint pk_planos primary key (id)
 );
 
 create table sessoes (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  usuario_id                    varchar(40),
-  ativa                         tinyint(1) default 0,
-  data_criacao                  datetime(6) not null,
+  usuario_id                    uuid,
+  ativa                         boolean,
+  data_criacao                  timestamp not null,
   constraint pk_sessoes primary key (id)
 );
 
 create table subareas (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   nome                          varchar(255),
   numero                        integer,
-  area_id                       varchar(40) not null,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  area_id                       uuid not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_subareas primary key (id)
 );
 
 create table tabela_entre_verdes (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   descricao                     varchar(255),
-  grupo_semaforico_id           varchar(40),
+  grupo_semaforico_id           uuid,
   posicao                       integer,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_tabela_entre_verdes primary key (id)
 );
 
 create table tabela_entre_verdes_transicao (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  tabela_entre_verdes_id        varchar(40),
-  transicao_id                  varchar(40),
+  tabela_entre_verdes_id        uuid,
+  transicao_id                  uuid,
   tempo_amarelo                 integer,
   tempo_vermelho_intermitente   integer,
   tempo_vermelho_limpeza        integer not null,
   tempo_atraso_grupo            integer not null,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_tabela_entre_verdes_transicao primary key (id)
 );
 
 create table tabela_horarios (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  versao_tabela_horaria_id      varchar(40) not null,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  versao_tabela_horaria_id      uuid not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint uq_tabela_horarios_versao_tabela_horaria_id unique (versao_tabela_horaria_id),
   constraint pk_tabela_horarios primary key (id)
 );
 
 create table transicoes (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
   tipo                          varchar(17) not null,
-  grupo_semaforico_id           varchar(40),
-  origem_id                     varchar(40),
-  destino_id                    varchar(40),
-  destroy                       tinyint(1) default 0,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  grupo_semaforico_id           uuid,
+  origem_id                     uuid,
+  destino_id                    uuid,
+  destroy                       boolean,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint ck_transicoes_tipo check (tipo in ('PERDA_DE_PASSAGEM','GANHO_DE_PASSAGEM')),
   constraint pk_transicoes primary key (id)
 );
 
 create table transicoes_proibidas (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  origem_id                     varchar(40) not null,
-  destino_id                    varchar(40) not null,
-  alternativo_id                varchar(40) not null,
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  origem_id                     uuid not null,
+  destino_id                    uuid not null,
+  alternativo_id                uuid not null,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_transicoes_proibidas primary key (id)
 );
 
 create table usuarios (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   senha                         varchar(255),
   id_json                       varchar(255),
   login                         varchar(255),
   email                         varchar(255),
   nome                          varchar(255),
-  root                          tinyint(1) default 0,
-  area_id                       varchar(40),
-  perfil_id                     varchar(40),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  root                          boolean,
+  area_id                       uuid,
+  perfil_id                     uuid,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint uq_usuarios_login unique (login),
   constraint pk_usuarios primary key (id)
 );
 
 create table verdes_conflitantes (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  origem_id                     varchar(40),
-  destino_id                    varchar(40),
-  data_criacao                  datetime(6) not null,
-  data_atualizacao              datetime(6) not null,
+  origem_id                     uuid,
+  destino_id                    uuid,
+  data_criacao                  timestamp not null,
+  data_atualizacao              timestamp not null,
   constraint pk_verdes_conflitantes primary key (id)
 );
 
 create table versoes_controladores (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  controlador_origem_id         varchar(40),
-  controlador_id                varchar(40),
-  controlador_fisico_id         varchar(40),
-  usuario_id                    varchar(40),
+  controlador_origem_id         uuid,
+  controlador_id                uuid,
+  controlador_fisico_id         uuid,
+  usuario_id                    uuid,
   descricao                     varchar(255),
   status_versao                 integer,
-  data_criacao                  datetime(6) not null,
+  data_criacao                  timestamp not null,
   constraint ck_versoes_controladores_status_versao check (status_versao in (0,1,2)),
   constraint uq_versoes_controladores_controlador_origem_id unique (controlador_origem_id),
   constraint uq_versoes_controladores_controlador_id unique (controlador_id),
@@ -434,28 +434,28 @@ create table versoes_controladores (
 );
 
 create table versoes_planos (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  versao_anterior_id            varchar(40),
-  anel_id                       varchar(40),
-  usuario_id                    varchar(40),
+  versao_anterior_id            uuid,
+  anel_id                       uuid,
+  usuario_id                    uuid,
   descricao                     varchar(255),
   status_versao                 integer,
-  data_criacao                  datetime(6) not null,
+  data_criacao                  timestamp not null,
   constraint ck_versoes_planos_status_versao check (status_versao in (0,1,2)),
   constraint uq_versoes_planos_versao_anterior_id unique (versao_anterior_id),
   constraint pk_versoes_planos primary key (id)
 );
 
 create table versoes_tabelas_horarias (
-  id                            varchar(40) not null,
+  id                            uuid not null,
   id_json                       varchar(255),
-  controlador_id                varchar(40),
-  tabela_horaria_origem_id      varchar(40),
-  usuario_id                    varchar(40),
+  controlador_id                uuid,
+  tabela_horaria_origem_id      uuid,
+  usuario_id                    uuid,
   descricao                     varchar(255),
   status_versao                 integer,
-  data_criacao                  datetime(6) not null,
+  data_criacao                  timestamp not null,
   constraint ck_versoes_tabelas_horarias_status_versao check (status_versao in (0,1,2)),
   constraint uq_versoes_tabelas_horarias_tabela_horaria_origem_id unique (tabela_horaria_origem_id),
   constraint pk_versoes_tabelas_horarias primary key (id)
@@ -630,171 +630,171 @@ create index ix_versoes_tabelas_horarias_usuario_id on versoes_tabelas_horarias 
 
 # --- !Downs
 
-alter table agrupamentos_controladores drop foreign key fk_agrupamentos_controladores_agrupamentos;
-drop index ix_agrupamentos_controladores_agrupamentos on agrupamentos_controladores;
+alter table agrupamentos_controladores drop constraint if exists fk_agrupamentos_controladores_agrupamentos;
+drop index if exists ix_agrupamentos_controladores_agrupamentos;
 
-alter table agrupamentos_controladores drop foreign key fk_agrupamentos_controladores_controladores;
-drop index ix_agrupamentos_controladores_controladores on agrupamentos_controladores;
+alter table agrupamentos_controladores drop constraint if exists fk_agrupamentos_controladores_controladores;
+drop index if exists ix_agrupamentos_controladores_controladores;
 
-alter table aneis drop foreign key fk_aneis_controlador_id;
-drop index ix_aneis_controlador_id on aneis;
+alter table aneis drop constraint if exists fk_aneis_controlador_id;
+drop index if exists ix_aneis_controlador_id;
 
-alter table aneis drop foreign key fk_aneis_croqui_id;
+alter table aneis drop constraint if exists fk_aneis_croqui_id;
 
-alter table areas drop foreign key fk_areas_cidade_id;
-drop index ix_areas_cidade_id on areas;
+alter table areas drop constraint if exists fk_areas_cidade_id;
+drop index if exists ix_areas_cidade_id;
 
-alter table atrasos_de_grupos drop foreign key fk_atrasos_de_grupos_transicao_id;
+alter table atrasos_de_grupos drop constraint if exists fk_atrasos_de_grupos_transicao_id;
 
-alter table controladores drop foreign key fk_controladores_modelo_id;
-drop index ix_controladores_modelo_id on controladores;
+alter table controladores drop constraint if exists fk_controladores_modelo_id;
+drop index if exists ix_controladores_modelo_id;
 
-alter table controladores drop foreign key fk_controladores_area_id;
-drop index ix_controladores_area_id on controladores;
+alter table controladores drop constraint if exists fk_controladores_area_id;
+drop index if exists ix_controladores_area_id;
 
-alter table controladores drop foreign key fk_controladores_subarea_id;
-drop index ix_controladores_subarea_id on controladores;
+alter table controladores drop constraint if exists fk_controladores_subarea_id;
+drop index if exists ix_controladores_subarea_id;
 
-alter table detectores drop foreign key fk_detectores_anel_id;
-drop index ix_detectores_anel_id on detectores;
+alter table detectores drop constraint if exists fk_detectores_anel_id;
+drop index if exists ix_detectores_anel_id;
 
-alter table detectores drop foreign key fk_detectores_estagio_id;
+alter table detectores drop constraint if exists fk_detectores_estagio_id;
 
-alter table detectores drop foreign key fk_detectores_controlador_id;
-drop index ix_detectores_controlador_id on detectores;
+alter table detectores drop constraint if exists fk_detectores_controlador_id;
+drop index if exists ix_detectores_controlador_id;
 
-alter table enderecos drop foreign key fk_enderecos_controlador_id;
+alter table enderecos drop constraint if exists fk_enderecos_controlador_id;
 
-alter table enderecos drop foreign key fk_enderecos_anel_id;
+alter table enderecos drop constraint if exists fk_enderecos_anel_id;
 
-alter table estagios drop foreign key fk_estagios_imagem_id;
+alter table estagios drop constraint if exists fk_estagios_imagem_id;
 
-alter table estagios drop foreign key fk_estagios_anel_id;
-drop index ix_estagios_anel_id on estagios;
+alter table estagios drop constraint if exists fk_estagios_anel_id;
+drop index if exists ix_estagios_anel_id;
 
-alter table estagios drop foreign key fk_estagios_controlador_id;
-drop index ix_estagios_controlador_id on estagios;
+alter table estagios drop constraint if exists fk_estagios_controlador_id;
+drop index if exists ix_estagios_controlador_id;
 
-alter table estagios_grupos_semaforicos drop foreign key fk_estagios_grupos_semaforicos_estagio_id;
-drop index ix_estagios_grupos_semaforicos_estagio_id on estagios_grupos_semaforicos;
+alter table estagios_grupos_semaforicos drop constraint if exists fk_estagios_grupos_semaforicos_estagio_id;
+drop index if exists ix_estagios_grupos_semaforicos_estagio_id;
 
-alter table estagios_grupos_semaforicos drop foreign key fk_estagios_grupos_semaforicos_grupo_semaforico_id;
-drop index ix_estagios_grupos_semaforicos_grupo_semaforico_id on estagios_grupos_semaforicos;
+alter table estagios_grupos_semaforicos drop constraint if exists fk_estagios_grupos_semaforicos_grupo_semaforico_id;
+drop index if exists ix_estagios_grupos_semaforicos_grupo_semaforico_id;
 
-alter table estagios_planos drop foreign key fk_estagios_planos_estagio_id;
-drop index ix_estagios_planos_estagio_id on estagios_planos;
+alter table estagios_planos drop constraint if exists fk_estagios_planos_estagio_id;
+drop index if exists ix_estagios_planos_estagio_id;
 
-alter table estagios_planos drop foreign key fk_estagios_planos_plano_id;
-drop index ix_estagios_planos_plano_id on estagios_planos;
+alter table estagios_planos drop constraint if exists fk_estagios_planos_plano_id;
+drop index if exists ix_estagios_planos_plano_id;
 
-alter table estagios_planos drop foreign key fk_estagios_planos_estagio_que_recebe_estagio_dispensavel_3;
-drop index ix_estagios_planos_estagio_que_recebe_estagio_dispensavel_3 on estagios_planos;
+alter table estagios_planos drop constraint if exists fk_estagios_planos_estagio_que_recebe_estagio_dispensavel_3;
+drop index if exists ix_estagios_planos_estagio_que_recebe_estagio_dispensavel_3;
 
-alter table eventos drop foreign key fk_eventos_tabela_horario_id;
-drop index ix_eventos_tabela_horario_id on eventos;
+alter table eventos drop constraint if exists fk_eventos_tabela_horario_id;
+drop index if exists ix_eventos_tabela_horario_id;
 
-alter table grupos_semaforicos drop foreign key fk_grupos_semaforicos_anel_id;
-drop index ix_grupos_semaforicos_anel_id on grupos_semaforicos;
+alter table grupos_semaforicos drop constraint if exists fk_grupos_semaforicos_anel_id;
+drop index if exists ix_grupos_semaforicos_anel_id;
 
-alter table grupos_semaforicos drop foreign key fk_grupos_semaforicos_controlador_id;
-drop index ix_grupos_semaforicos_controlador_id on grupos_semaforicos;
+alter table grupos_semaforicos drop constraint if exists fk_grupos_semaforicos_controlador_id;
+drop index if exists ix_grupos_semaforicos_controlador_id;
 
-alter table grupos_semaforicos_planos drop foreign key fk_grupos_semaforicos_planos_grupo_semaforico_id;
-drop index ix_grupos_semaforicos_planos_grupo_semaforico_id on grupos_semaforicos_planos;
+alter table grupos_semaforicos_planos drop constraint if exists fk_grupos_semaforicos_planos_grupo_semaforico_id;
+drop index if exists ix_grupos_semaforicos_planos_grupo_semaforico_id;
 
-alter table grupos_semaforicos_planos drop foreign key fk_grupos_semaforicos_planos_plano_id;
-drop index ix_grupos_semaforicos_planos_plano_id on grupos_semaforicos_planos;
+alter table grupos_semaforicos_planos drop constraint if exists fk_grupos_semaforicos_planos_plano_id;
+drop index if exists ix_grupos_semaforicos_planos_plano_id;
 
-alter table limite_area drop foreign key fk_limite_area_area_id;
-drop index ix_limite_area_area_id on limite_area;
+alter table limite_area drop constraint if exists fk_limite_area_area_id;
+drop index if exists ix_limite_area_area_id;
 
-alter table modelo_controladores drop foreign key fk_modelo_controladores_fabricante_id;
-drop index ix_modelo_controladores_fabricante_id on modelo_controladores;
+alter table modelo_controladores drop constraint if exists fk_modelo_controladores_fabricante_id;
+drop index if exists ix_modelo_controladores_fabricante_id;
 
-alter table permissoes_perfis drop foreign key fk_permissoes_perfis_perfis;
-drop index ix_permissoes_perfis_perfis on permissoes_perfis;
+alter table permissoes_perfis drop constraint if exists fk_permissoes_perfis_perfis;
+drop index if exists ix_permissoes_perfis_perfis;
 
-alter table permissoes_perfis drop foreign key fk_permissoes_perfis_permissoes;
-drop index ix_permissoes_perfis_permissoes on permissoes_perfis;
+alter table permissoes_perfis drop constraint if exists fk_permissoes_perfis_permissoes;
+drop index if exists ix_permissoes_perfis_permissoes;
 
-alter table planos drop foreign key fk_planos_versao_plano_id;
-drop index ix_planos_versao_plano_id on planos;
+alter table planos drop constraint if exists fk_planos_versao_plano_id;
+drop index if exists ix_planos_versao_plano_id;
 
-alter table planos drop foreign key fk_planos_agrupamento_id;
-drop index ix_planos_agrupamento_id on planos;
+alter table planos drop constraint if exists fk_planos_agrupamento_id;
+drop index if exists ix_planos_agrupamento_id;
 
-alter table sessoes drop foreign key fk_sessoes_usuario_id;
-drop index ix_sessoes_usuario_id on sessoes;
+alter table sessoes drop constraint if exists fk_sessoes_usuario_id;
+drop index if exists ix_sessoes_usuario_id;
 
-alter table subareas drop foreign key fk_subareas_area_id;
-drop index ix_subareas_area_id on subareas;
+alter table subareas drop constraint if exists fk_subareas_area_id;
+drop index if exists ix_subareas_area_id;
 
-alter table tabela_entre_verdes drop foreign key fk_tabela_entre_verdes_grupo_semaforico_id;
-drop index ix_tabela_entre_verdes_grupo_semaforico_id on tabela_entre_verdes;
+alter table tabela_entre_verdes drop constraint if exists fk_tabela_entre_verdes_grupo_semaforico_id;
+drop index if exists ix_tabela_entre_verdes_grupo_semaforico_id;
 
-alter table tabela_entre_verdes_transicao drop foreign key fk_tabela_entre_verdes_transicao_tabela_entre_verdes_id;
-drop index ix_tabela_entre_verdes_transicao_tabela_entre_verdes_id on tabela_entre_verdes_transicao;
+alter table tabela_entre_verdes_transicao drop constraint if exists fk_tabela_entre_verdes_transicao_tabela_entre_verdes_id;
+drop index if exists ix_tabela_entre_verdes_transicao_tabela_entre_verdes_id;
 
-alter table tabela_entre_verdes_transicao drop foreign key fk_tabela_entre_verdes_transicao_transicao_id;
-drop index ix_tabela_entre_verdes_transicao_transicao_id on tabela_entre_verdes_transicao;
+alter table tabela_entre_verdes_transicao drop constraint if exists fk_tabela_entre_verdes_transicao_transicao_id;
+drop index if exists ix_tabela_entre_verdes_transicao_transicao_id;
 
-alter table tabela_horarios drop foreign key fk_tabela_horarios_versao_tabela_horaria_id;
+alter table tabela_horarios drop constraint if exists fk_tabela_horarios_versao_tabela_horaria_id;
 
-alter table transicoes drop foreign key fk_transicoes_grupo_semaforico_id;
-drop index ix_transicoes_grupo_semaforico_id on transicoes;
+alter table transicoes drop constraint if exists fk_transicoes_grupo_semaforico_id;
+drop index if exists ix_transicoes_grupo_semaforico_id;
 
-alter table transicoes drop foreign key fk_transicoes_origem_id;
-drop index ix_transicoes_origem_id on transicoes;
+alter table transicoes drop constraint if exists fk_transicoes_origem_id;
+drop index if exists ix_transicoes_origem_id;
 
-alter table transicoes drop foreign key fk_transicoes_destino_id;
-drop index ix_transicoes_destino_id on transicoes;
+alter table transicoes drop constraint if exists fk_transicoes_destino_id;
+drop index if exists ix_transicoes_destino_id;
 
-alter table transicoes_proibidas drop foreign key fk_transicoes_proibidas_origem_id;
-drop index ix_transicoes_proibidas_origem_id on transicoes_proibidas;
+alter table transicoes_proibidas drop constraint if exists fk_transicoes_proibidas_origem_id;
+drop index if exists ix_transicoes_proibidas_origem_id;
 
-alter table transicoes_proibidas drop foreign key fk_transicoes_proibidas_destino_id;
-drop index ix_transicoes_proibidas_destino_id on transicoes_proibidas;
+alter table transicoes_proibidas drop constraint if exists fk_transicoes_proibidas_destino_id;
+drop index if exists ix_transicoes_proibidas_destino_id;
 
-alter table transicoes_proibidas drop foreign key fk_transicoes_proibidas_alternativo_id;
-drop index ix_transicoes_proibidas_alternativo_id on transicoes_proibidas;
+alter table transicoes_proibidas drop constraint if exists fk_transicoes_proibidas_alternativo_id;
+drop index if exists ix_transicoes_proibidas_alternativo_id;
 
-alter table usuarios drop foreign key fk_usuarios_area_id;
-drop index ix_usuarios_area_id on usuarios;
+alter table usuarios drop constraint if exists fk_usuarios_area_id;
+drop index if exists ix_usuarios_area_id;
 
-alter table usuarios drop foreign key fk_usuarios_perfil_id;
-drop index ix_usuarios_perfil_id on usuarios;
+alter table usuarios drop constraint if exists fk_usuarios_perfil_id;
+drop index if exists ix_usuarios_perfil_id;
 
-alter table verdes_conflitantes drop foreign key fk_verdes_conflitantes_origem_id;
-drop index ix_verdes_conflitantes_origem_id on verdes_conflitantes;
+alter table verdes_conflitantes drop constraint if exists fk_verdes_conflitantes_origem_id;
+drop index if exists ix_verdes_conflitantes_origem_id;
 
-alter table verdes_conflitantes drop foreign key fk_verdes_conflitantes_destino_id;
-drop index ix_verdes_conflitantes_destino_id on verdes_conflitantes;
+alter table verdes_conflitantes drop constraint if exists fk_verdes_conflitantes_destino_id;
+drop index if exists ix_verdes_conflitantes_destino_id;
 
-alter table versoes_controladores drop foreign key fk_versoes_controladores_controlador_origem_id;
+alter table versoes_controladores drop constraint if exists fk_versoes_controladores_controlador_origem_id;
 
-alter table versoes_controladores drop foreign key fk_versoes_controladores_controlador_id;
+alter table versoes_controladores drop constraint if exists fk_versoes_controladores_controlador_id;
 
-alter table versoes_controladores drop foreign key fk_versoes_controladores_controlador_fisico_id;
-drop index ix_versoes_controladores_controlador_fisico_id on versoes_controladores;
+alter table versoes_controladores drop constraint if exists fk_versoes_controladores_controlador_fisico_id;
+drop index if exists ix_versoes_controladores_controlador_fisico_id;
 
-alter table versoes_controladores drop foreign key fk_versoes_controladores_usuario_id;
-drop index ix_versoes_controladores_usuario_id on versoes_controladores;
+alter table versoes_controladores drop constraint if exists fk_versoes_controladores_usuario_id;
+drop index if exists ix_versoes_controladores_usuario_id;
 
-alter table versoes_planos drop foreign key fk_versoes_planos_versao_anterior_id;
+alter table versoes_planos drop constraint if exists fk_versoes_planos_versao_anterior_id;
 
-alter table versoes_planos drop foreign key fk_versoes_planos_anel_id;
-drop index ix_versoes_planos_anel_id on versoes_planos;
+alter table versoes_planos drop constraint if exists fk_versoes_planos_anel_id;
+drop index if exists ix_versoes_planos_anel_id;
 
-alter table versoes_planos drop foreign key fk_versoes_planos_usuario_id;
-drop index ix_versoes_planos_usuario_id on versoes_planos;
+alter table versoes_planos drop constraint if exists fk_versoes_planos_usuario_id;
+drop index if exists ix_versoes_planos_usuario_id;
 
-alter table versoes_tabelas_horarias drop foreign key fk_versoes_tabelas_horarias_controlador_id;
-drop index ix_versoes_tabelas_horarias_controlador_id on versoes_tabelas_horarias;
+alter table versoes_tabelas_horarias drop constraint if exists fk_versoes_tabelas_horarias_controlador_id;
+drop index if exists ix_versoes_tabelas_horarias_controlador_id;
 
-alter table versoes_tabelas_horarias drop foreign key fk_versoes_tabelas_horarias_tabela_horaria_origem_id;
+alter table versoes_tabelas_horarias drop constraint if exists fk_versoes_tabelas_horarias_tabela_horaria_origem_id;
 
-alter table versoes_tabelas_horarias drop foreign key fk_versoes_tabelas_horarias_usuario_id;
-drop index ix_versoes_tabelas_horarias_usuario_id on versoes_tabelas_horarias;
+alter table versoes_tabelas_horarias drop constraint if exists fk_versoes_tabelas_horarias_usuario_id;
+drop index if exists ix_versoes_tabelas_horarias_usuario_id;
 
 drop table if exists agrupamentos;
 

--- a/influunt-api/test/controllers/AbstractInfluuntControladorTest.java
+++ b/influunt-api/test/controllers/AbstractInfluuntControladorTest.java
@@ -50,6 +50,12 @@ public abstract class AbstractInfluuntControladorTest extends WithApplication {
         area.setDescricao(1);
         area.save();
 
+        Subarea subarea = new Subarea();
+        subarea.setArea(area);
+        subarea.setNome("Subarea 1");
+        subarea.setNumero(1);
+        subarea.save();
+
         Fabricante fabricante = new Fabricante();
         fabricante.setNome("Tesc");
         fabricante.save();
@@ -59,7 +65,7 @@ public abstract class AbstractInfluuntControladorTest extends WithApplication {
         modeloControlador.setDescricao("Modelo 1");
         modeloControlador.save();
 
-        controladorTestUtils = new ControladorTestUtil(cidade, area, fabricante, modeloControlador);
+        controladorTestUtils = new ControladorTestUtil(cidade, area, subarea, fabricante, modeloControlador);
     }
 
     public abstract List<Erro> getErros(Controlador controlador);

--- a/influunt-api/test/controllers/ControladoresControllerTest.java
+++ b/influunt-api/test/controllers/ControladoresControllerTest.java
@@ -108,6 +108,7 @@ public class ControladoresControllerTest extends AbstractInfluuntControladorTest
         assertEquals("Teste de Aneis", controlador.getAneis().size(), controladorClonado.getAneis().size());
         assertEquals("Teste de Agrupamentos", controlador.getAgrupamentos().size(), controladorClonado.getAgrupamentos().size());
         assertEquals("Teste de Area", controlador.getArea(), controladorClonado.getArea());
+        assertEquals("Teste de Subarea", controlador.getSubarea(), controladorClonado.getSubarea());
         assertEquals("Teste de Modelo", controlador.getModelo(), controladorClonado.getModelo());
         assertEquals("Teste de Controlador Fisico", controlador.getVersaoControlador().getControladorFisico(), controladorClonado.getVersaoControlador().getControladorFisico());
         assertEquals("Total de Versoes", 2, controladorClonado.getVersaoControlador().getControladorFisico().getVersoes().size());
@@ -290,6 +291,7 @@ public class ControladoresControllerTest extends AbstractInfluuntControladorTest
         assertEquals("Teste de Aneis", controlador.getAneis().size(), controladorClonado.getAneis().size());
         assertEquals("Teste de Agrupamentos", controlador.getAgrupamentos().size(), controladorClonado.getAgrupamentos().size());
         assertEquals("Teste de Area", controlador.getArea(), controladorClonado.getArea());
+        assertEquals("Teste de Subarea", controlador.getSubarea(), controladorClonado.getSubarea());
         assertEquals("Teste de Modelo", controlador.getModelo(), controladorClonado.getModelo());
         assertEquals("Teste de Controlador Fisico", controlador.getVersaoControlador().getControladorFisico(), controladorClonado.getVersaoControlador().getControladorFisico());
         assertEquals("Total de Versoes", 2, controladorClonado.getVersaoControlador().getControladorFisico().getVersoes().size());

--- a/influunt-api/test/models/ControladorAneisTest.java
+++ b/influunt-api/test/models/ControladorAneisTest.java
@@ -206,6 +206,11 @@ public class ControladorAneisTest extends ControladorTest {
         area.setDescricao(2);
         area.save();
 
+        Subarea subarea = new Subarea();
+        subarea.setArea(area);
+        subarea.setNumero(234);
+        subarea.save();
+
         Controlador c1A1 = getControladorAneis();
         Controlador c2A1 = getControladorAneis();
 
@@ -234,10 +239,10 @@ public class ControladorAneisTest extends ControladorTest {
         assertEquals(c1A2.getArea().getId().toString(), c2A2.getArea().getId().toString());
         assertNotEquals(c1A1.getArea().getId().toString(), c1A2.getArea().getId().toString());
 
-        assertEquals("1.000.0001", c1A1.getCLC());
-        assertEquals("1.000.0002", c2A1.getCLC());
-        assertEquals("2.000.0001", c1A2.getCLC());
-        assertEquals("2.000.0002", c2A2.getCLC());
+        assertEquals("1.010.0001", c1A1.getCLC());
+        assertEquals("1.010.0002", c2A1.getCLC());
+        assertEquals("2.010.0001", c1A2.getCLC());
+        assertEquals("2.010.0002", c2A2.getCLC());
 
         List<Anel> aneisC1A1 = c1A1.getAneis().stream().sorted((o1, o2) -> o1.getPosicao().compareTo(o2.getPosicao())).collect(Collectors.toList());
         List<Anel> aneisC2A1 = c2A1.getAneis().stream().sorted((o1, o2) -> o1.getPosicao().compareTo(o2.getPosicao())).collect(Collectors.toList());
@@ -245,7 +250,7 @@ public class ControladorAneisTest extends ControladorTest {
         List<Anel> aneisC2A2 = c2A2.getAneis().stream().sorted((o1, o2) -> o1.getPosicao().compareTo(o2.getPosicao())).collect(Collectors.toList());
 
 
-        assertEquals("1.000.0001.1", aneisC1A1.get(0).getCLA());
+        assertEquals("1.000.1001.1", aneisC1A1.get(0).getCLA());
         assertEquals("1.000.0001.2", aneisC1A1.get(1).getCLA());
         assertEquals("1.000.0001.3", aneisC1A1.get(2).getCLA());
         assertEquals("1.000.0001.4", aneisC1A1.get(3).getCLA());

--- a/influunt-api/test/models/ControladorAneisTest.java
+++ b/influunt-api/test/models/ControladorAneisTest.java
@@ -239,10 +239,10 @@ public class ControladorAneisTest extends ControladorTest {
         assertEquals(c1A2.getArea().getId().toString(), c2A2.getArea().getId().toString());
         assertNotEquals(c1A1.getArea().getId().toString(), c1A2.getArea().getId().toString());
 
-        assertEquals("1.010.0001", c1A1.getCLC());
-        assertEquals("1.010.0002", c2A1.getCLC());
-        assertEquals("2.010.0001", c1A2.getCLC());
-        assertEquals("2.010.0002", c2A2.getCLC());
+        assertEquals("1.001.0001", c1A1.getCLC());
+        assertEquals("1.001.0002", c2A1.getCLC());
+        assertEquals("2.001.0001", c1A2.getCLC());
+        assertEquals("2.001.0002", c2A2.getCLC());
 
         List<Anel> aneisC1A1 = c1A1.getAneis().stream().sorted((o1, o2) -> o1.getPosicao().compareTo(o2.getPosicao())).collect(Collectors.toList());
         List<Anel> aneisC2A1 = c2A1.getAneis().stream().sorted((o1, o2) -> o1.getPosicao().compareTo(o2.getPosicao())).collect(Collectors.toList());
@@ -250,27 +250,32 @@ public class ControladorAneisTest extends ControladorTest {
         List<Anel> aneisC2A2 = c2A2.getAneis().stream().sorted((o1, o2) -> o1.getPosicao().compareTo(o2.getPosicao())).collect(Collectors.toList());
 
 
-        assertEquals("1.000.1001.1", aneisC1A1.get(0).getCLA());
-        assertEquals("1.000.0001.2", aneisC1A1.get(1).getCLA());
-        assertEquals("1.000.0001.3", aneisC1A1.get(2).getCLA());
-        assertEquals("1.000.0001.4", aneisC1A1.get(3).getCLA());
+        assertEquals("1.001.0001.1", aneisC1A1.get(0).getCLA());
+        assertEquals("1.001.0001.2", aneisC1A1.get(1).getCLA());
+        assertEquals("1.001.0001.3", aneisC1A1.get(2).getCLA());
+        assertEquals("1.001.0001.4", aneisC1A1.get(3).getCLA());
 
-        assertEquals("1.000.0002.1", aneisC2A1.get(0).getCLA());
-        assertEquals("1.000.0002.2", aneisC2A1.get(1).getCLA());
-        assertEquals("1.000.0002.3", aneisC2A1.get(2).getCLA());
-        assertEquals("1.000.0002.4", aneisC2A1.get(3).getCLA());
+        assertEquals("1.001.0002.1", aneisC2A1.get(0).getCLA());
+        assertEquals("1.001.0002.2", aneisC2A1.get(1).getCLA());
+        assertEquals("1.001.0002.3", aneisC2A1.get(2).getCLA());
+        assertEquals("1.001.0002.4", aneisC2A1.get(3).getCLA());
 
-        assertEquals("2.000.0001.1", aneisC1A2.get(0).getCLA());
-        assertEquals("2.000.0001.2", aneisC1A2.get(1).getCLA());
-        assertEquals("2.000.0001.3", aneisC1A2.get(2).getCLA());
-        assertEquals("2.000.0001.4", aneisC1A2.get(3).getCLA());
+        assertEquals("2.001.0001.1", aneisC1A2.get(0).getCLA());
+        assertEquals("2.001.0001.2", aneisC1A2.get(1).getCLA());
+        assertEquals("2.001.0001.3", aneisC1A2.get(2).getCLA());
+        assertEquals("2.001.0001.4", aneisC1A2.get(3).getCLA());
 
-        assertEquals("2.000.0002.1", aneisC2A2.get(0).getCLA());
-        assertEquals("2.000.0002.2", aneisC2A2.get(1).getCLA());
-        assertEquals("2.000.0002.3", aneisC2A2.get(2).getCLA());
+        assertEquals("2.001.0002.1", aneisC2A2.get(0).getCLA());
+        assertEquals("2.001.0002.2", aneisC2A2.get(1).getCLA());
+        assertEquals("2.001.0002.3", aneisC2A2.get(2).getCLA());
+        assertEquals("2.001.0002.4", aneisC2A2.get(3).getCLA());
+
+
+        aneisC2A2.get(3).getControlador().setSubarea(null);
         assertEquals("2.000.0002.4", aneisC2A2.get(3).getCLA());
 
-
+        aneisC2A2.get(3).getControlador().setSubarea(subarea);
+        assertEquals("2.234.0002.4", aneisC2A2.get(3).getCLA());
     }
 
 }

--- a/influunt-api/test/models/ControladorDadosBasicosTest.java
+++ b/influunt-api/test/models/ControladorDadosBasicosTest.java
@@ -210,9 +210,11 @@ public class ControladorDadosBasicosTest extends ControladorTest {
 
         Controlador c1A2 = getControladorDadosBasicos();
         c1A2.setArea(area);
+        c1A2.setSubarea(null);
 
         Controlador c2A2 = getControladorDadosBasicos();
         c2A2.setArea(area);
+        c2A2.setSubarea(null);
 
         c1A1.save();
         c2A1.save();
@@ -222,8 +224,8 @@ public class ControladorDadosBasicosTest extends ControladorTest {
         assertEquals(c1A1.getArea().getId().toString(), c2A1.getArea().getId().toString());
         assertEquals(c1A2.getArea().getId().toString(), c2A2.getArea().getId().toString());
 
-        assertEquals("1.000.0001", c1A1.getCLC());
-        assertEquals("1.000.0002", c2A1.getCLC());
+        assertEquals("1.001.0001", c1A1.getCLC());
+        assertEquals("1.001.0002", c2A1.getCLC());
         assertEquals("2.000.0001", c1A2.getCLC());
         assertEquals("2.000.0002", c2A2.getCLC());
 
@@ -234,8 +236,8 @@ public class ControladorDadosBasicosTest extends ControladorTest {
 
         c1A2.setSubarea(subarea);
 
-        assertEquals("1.000.0001", c1A1.getCLC());
-        assertEquals("1.000.0002", c2A1.getCLC());
+        assertEquals("1.001.0001", c1A1.getCLC());
+        assertEquals("1.001.0002", c2A1.getCLC());
         assertEquals("2.234.0001", c1A2.getCLC());
         assertEquals("2.000.0002", c2A2.getCLC());
     }

--- a/influunt-api/test/models/ControladorTest.java
+++ b/influunt-api/test/models/ControladorTest.java
@@ -52,6 +52,12 @@ public abstract class ControladorTest extends WithApplication {
         area.setDescricao(1);
         area.save();
 
+        Subarea subarea = new Subarea();
+        subarea.setArea(area);
+        subarea.setNome("Subarea 1");
+        subarea.setNumero(1);
+        subarea.save();
+
         Fabricante fabricante = new Fabricante();
         fabricante.setNome("Tesc");
         fabricante.save();
@@ -68,7 +74,7 @@ public abstract class ControladorTest extends WithApplication {
         usuario.setEmail("abc@influunt.com.br");
         usuario.save();
 
-        controladorTestUtils = new ControladorTestUtil(cidade, area, fabricante, modeloControlador);
+        controladorTestUtils = new ControladorTestUtil(cidade, area, subarea, fabricante, modeloControlador);
     }
 
     protected Controlador getControlador() {

--- a/influunt-api/test/models/ControladorTestUtil.java
+++ b/influunt-api/test/models/ControladorTestUtil.java
@@ -14,13 +14,15 @@ public class ControladorTestUtil {
 
     private Cidade cidade;
     private Area area;
+    private Subarea subarea;
     private Fabricante fabricante;
     private ModeloControlador modeloControlador;
     private Usuario usuario;
 
-    public ControladorTestUtil(Cidade cidade, Area area, Fabricante fabricante, ModeloControlador modeloControlador) {
+    public ControladorTestUtil(Cidade cidade, Area area, Subarea subarea, Fabricante fabricante, ModeloControlador modeloControlador) {
         this.cidade = cidade;
         this.area = area;
+        this.subarea = subarea;
         this.fabricante = fabricante;
         this.modeloControlador = modeloControlador;
     }
@@ -33,6 +35,7 @@ public class ControladorTestUtil {
 
         Controlador controlador = getControlador();
         controlador.setArea(this.area);
+        controlador.setSubarea(this.subarea);
         controlador.setModelo(this.modeloControlador);
         controlador.setNumeroSMEE("1234");
         controlador.setNumeroSMEEConjugado1("C1");


### PR DESCRIPTION
O bug era quando o controlador estava ativo, e o usuário clicava em editar, o sistema realiza uma copia do controlador, e não estava criando a nova copia com a subárea 