### PR TITLE
Validação que não há nada a preencher por anel.

### DIFF
--- a/influunt-app/app/scripts/controllers/controladores/atraso-de-grupo.js
+++ b/influunt-app/app/scripts/controllers/controladores/atraso-de-grupo.js
@@ -54,9 +54,7 @@ angular.module('influuntApp')
             $scope.selecionaAnel(index);
             $scope.atualizaGruposSemaforicos();
             $scope.selecionaGrupoSemaforico($scope.currentGruposSemaforicos[0], 0);
-
             $scope.setAtributos();
-
             $scope.inicializaConfirmacaoNadaHaPreencher();
           }
         });
@@ -79,8 +77,8 @@ angular.module('influuntApp')
         $scope.selecionaAnel(index);
         $scope.atualizaGruposSemaforicos();
         $scope.selecionaGrupoSemaforico($scope.currentGruposSemaforicos[0], 0);
-        
         $scope.setAtributos();
+        $scope.inicializaConfirmacaoNadaHaPreencher();
       };
 
       $scope.$watch('currentTransicoesComPerdaDePassagem', function() {


### PR DESCRIPTION
 Corrigi bug "Na edição de atraso de grupo só é necessário marcar para um grupo para poder avançar. A confirmação é por anel, se no anel 1."