### PR TITLE
Liberando o botão salvar após alterar o knob de atraso de grupo

### DIFF
--- a/influunt-app/app/views/controladores/wizard/atraso-de-grupo.html
+++ b/influunt-app/app/views/controladores/wizard/atraso-de-grupo.html
@@ -66,7 +66,8 @@
                                           label="SEG"
                                           min="atrasoGrupoMin"
                                           max="atrasoGrupoMax"
-                                          data-ng-model="transicao.atrasoDeGrupo.atrasoDeGrupo">
+                                          data-ng-model="transicao.atrasoDeGrupo.atrasoDeGrupo"
+                                          data-ng-click="inicializaConfirmacaoNadaHaPreencher()">
                                         </influunt-knob>
                                       </div>
                                     </div>


### PR DESCRIPTION
Resolvendo o bug "Na edição de atraso de grupo só é necessário marcar para um grupo para poder avancar. A confirmação é por anel, se no anel 1." encontrado por Rodrigo