### PR TITLE
fix erro tabela horária

### DIFF
--- a/influunt-app/app/views/tabela_horarios/tabelas.html
+++ b/influunt-app/app/views/tabela_horarios/tabelas.html
@@ -23,7 +23,7 @@
         on-verifica-atualizacao-de-eventos="verificaAtualizacaoDeEventos"
         on-visualizar-plano="visualizarPlano"
         on-remover-evento="removerEvento"
-        erros="errors.versoesTabelasHorarias[currentVersaoTabelaHorariaIndex].tabelaHoraria.eventos"
+        erros="errors.versoesTabelasHorarias[currentVersaoTabelaHorariaIndex].tabelaHoraria.eventos[$index]"
         read-only="somenteVisualizacao">
       </tr>
       <tr influunt-evento="visualizarPlano"


### PR DESCRIPTION
Corrige o erro da linha 42 da planilha:
>Quando você seleciona um plano que não está configurado o erro aparece em todos os eventos mesmo que o evento tenha um plano configurado. Ex: Configura o plano 1, cria dois eventos um com plano 1 e outro com o plano 2 o erro vai retornar e aparecer em todos os eventos, se depois você alterar o enveto que esta com o plano 2 para plano 1 e salvar o sistema salva corretamente