### PR TITLE
fixes #1377

### DIFF
--- a/influunt-app/app/scripts/controllers/planos.js
+++ b/influunt-app/app/scripts/controllers/planos.js
@@ -64,10 +64,21 @@ angular.module('influuntApp')
               }
             });
 
+            $scope.configuraModoManualExclusivo();
             $scope.selecionaAnelPlanos(0);
             return atualizaDiagramaIntervalos();
           })
           .finally(influuntBlockui.unblock);
+      };
+
+      $scope.configuraModoManualExclusivo = function() {
+        $scope.obrigaModoManualExclusivo = _.filter($scope.objeto.aneis, {ativo: true, aceitaModoManual: true}).length > 1;
+        _
+          .chain($scope.objeto.planos)
+          .filter({modoOperacao: 'MANUAL'})
+          .each(function(p) {
+            p.configurado = p.configurado || $scope.obrigaModoManualExclusivo;
+          }).value();
       };
 
       $scope.clonarPlanos = function(controladorId) {
@@ -293,13 +304,16 @@ angular.module('influuntApp')
         selecionaAnel(index);
 
         var indexPlano = 0;
+        var deveAtivarPlano = false;
         if (angular.isDefined($scope.currentPlano)) {
           indexPlano = _.findIndex($scope.currentPlanos, {posicao: $scope.currentPlano.posicao});
           indexPlano = indexPlano >= 0 ? indexPlano : 0;
+          deveAtivarPlano = $scope.currentPlano.configurado;
         }
 
         $scope.selecionaPlano($scope.currentPlanos[indexPlano], indexPlano);
-        $scope.currentPlano.configurado = true;
+        // Deverá somente ativar o plano de mesma posição em outros aneis se o plano atual também estiver ativo.
+        $scope.currentPlano.configurado = $scope.currentPlano.configurado || deveAtivarPlano;
       };
 
       $scope.selecionaPlano = function(plano, index) {

--- a/influunt-app/app/views/planos/criacao-planos.html
+++ b/influunt-app/app/views/planos/criacao-planos.html
@@ -117,7 +117,11 @@
                                   data-ng-class="{active: $index === currentPlanoIndex}"
                                   class="item-menu",
                                   id="plano_{{plano.posicao}}">
-                                    <input type="checkbox" ichecks data-ng-model="plano.configurado" data-if-unchecked="resetarPlano(plano, $index)" data-is-disabled="plano.posicao === 1 || somenteVisualizacao" data-if-changed="selecionaPlano(plano, $index)">
+                                    <input type="checkbox"
+                                        ichecks data-ng-model="plano.configurado"
+                                        data-if-unchecked="resetarPlano(plano, $index)"
+                                        data-is-disabled="plano.posicao === 1 || (plano.modoOperacao === 'MANUAL' && obrigaModoManualExclusivo) || somenteVisualizacao"
+                                        data-if-changed="selecionaPlano(plano, $index)">
 
                                     <span class="nome-plano" data-ng-class="{configurado: plano.configurado}">
                                       {{'tabelaHorarios.plano' | translate}} {{ plano.modoOperacao === 'MANUAL' ? ('planos.modoManual' | translate) : plano.posicao }}

--- a/influunt-app/test/spec/controllers/planos.js
+++ b/influunt-app/test/spec/controllers/planos.js
@@ -68,8 +68,8 @@ describe('Controller: PlanosCtrl', function () {
   });
 
   describe('init - controlador mínimo', function () {
-    beforeEach(function() { 
-      beforeEachFn(ControladorComVariosAneis); 
+    beforeEach(function() {
+      beforeEachFn(ControladorComVariosAneis);
     });
     it('O plano 1 deve estar ativo e ser coordenado', function() {
       var aneis = _.filter(scope.objeto.aneis, 'ativo');
@@ -79,14 +79,14 @@ describe('Controller: PlanosCtrl', function () {
         expect(plano.modoOperacao).toBe('TEMPO_FIXO_COORDENADO');
       });
     });
-    
+
     it('Se o plano 2 estiver selecionado, ao trocar de anel o mesmo numero deve continuar selecionado e ser ativo', function() {
       var planoAnel1 = _.cloneDeep(scope.currentPlano);
       scope.selecionaAnelPlanos(1);
       var planoAnel2 = _.cloneDeep(scope.currentPlano);
       expect(planoAnel1.configurado).toBeTruthy();
       expect(planoAnel1.posicao).toBe(1);
-      
+
       expect(planoAnel2.configurado).toBeTruthy();
       expect(planoAnel2.posicao).toBe(1);
     });
@@ -1170,6 +1170,28 @@ describe('Controller: PlanosCtrl', function () {
       scope.currentPlano.tempoCiclo = 45;
       expect(scope.getErrosPlanos(erros)[1]).toBe('A soma dos tempos dos estágios (0s) é diferente do tempo de ciclo (30s).');
     });
-
   });
+
+  describe('Troca de aneis', function () {
+    beforeEach(function() { beforeEachFn(ControladorComVariosAneisEPlanos); });
+
+    describe('Modo manual obrigatório', function () {
+      it('um controlador com um anel que aceite modo manual deverá permitir que o usuário desative o plano exclusivo manual', function() {
+        _.filter(scope.objeto.aneis, 'ativo').forEach(function(anel, index) { anel.aceitaModoManual = index === 0; });
+        scope.configuraModoManualExclusivo();
+        scope.$apply();
+
+        expect(scope.obrigaModoManualExclusivo).toBeFalsy();
+      });
+
+      it('um controlador com mais que um anel não deverá permitir que o usuário desative o plano exclusivo manual', function() {
+        _.filter(scope.objeto.aneis, 'ativo').forEach(function(anel, index) { anel.aceitaModoManual = true; });
+        scope.configuraModoManualExclusivo();
+        scope.$apply();
+
+        expect(scope.obrigaModoManualExclusivo).toBeTruthy();
+      });
+    });
+  });
+
 });


### PR DESCRIPTION
fixes #1377: Todos os aneis que aceitam plano manual exclusivo deverão ter o este plano configurado, se a quantidade de aneis no controlador for maior que 1.

Altera também o comportamento anterior da lista de planos: Se o usuário troca do `anel 1` para `anel 2` estando no `plano 2`, o `plano 2` estaria selecionado no `anel 2` e seria colocado como `configurado` automaticamente. Isto somente deverá ocorrer se o `plano 2` em `anel 1` estiver configurado.