### PR TITLE
Validação transição proibida com destino demanda prioritária

### DIFF
--- a/influunt-api/conf/logback.xml
+++ b/influunt-api/conf/logback.xml
@@ -56,7 +56,7 @@
   <logger name="org.jdbcdslog.StatementLogger"  level="OFF" /> <!-- Will log all statements -->
   <logger name="org.jdbcdslog.ResultSetLogger"  level="OFF"  /> <!-- Won' log result sets -->
 
-  <root level="INFO">
+  <root level="WARN">
     <appender-ref ref="ASYNCFILE" />
     <appender-ref ref="ASYNCSTDOUT" />
   </root>

--- a/influunt-api/modules/influunt-core/app/models/Estagio.java
+++ b/influunt-api/modules/influunt-core/app/models/Estagio.java
@@ -369,7 +369,7 @@ public class Estagio extends Model implements Serializable, Cloneable {
         return true;
     }
 
-    @AssertTrue(groups = ControladorAssociacaoGruposSemaforicosCheck.class, message = "O Tempo de verde do estágio de demanda priortária deve estar entre {min} e {max}")
+    @AssertTrue(groups = ControladorAssociacaoGruposSemaforicosCheck.class, message = "O Tempo de verde do estágio de demanda prioritária deve estar entre {min} e {max}")
     public boolean isTempoVerdeDemandaPrioritaria() {
         if (isDemandaPrioritaria()) {
             return getTempoVerdeDemandaPrioritaria() != null &&

--- a/influunt-api/modules/influunt-core/app/models/Subarea.java
+++ b/influunt-api/modules/influunt-core/app/models/Subarea.java
@@ -161,7 +161,7 @@ public class Subarea extends Model implements Cloneable, Serializable {
     }
 
     @AssertTrue(groups = SubareasCheck.class,
-        message = "Já existe uma Subarea cadastrada com esse nome.")
+        message = "Já existe uma subárea cadastrada com esse nome.")
     public boolean isNomeUnique() {
         if (Objects.nonNull(getNome())) {
             Subarea subareaAux = Subarea.find.where().eq("area_id", getArea().getId().toString()).ieq("nome", getNome().toString()).findUnique();

--- a/influunt-api/modules/influunt-core/app/models/TransicaoProibida.java
+++ b/influunt-api/modules/influunt-core/app/models/TransicaoProibida.java
@@ -154,6 +154,15 @@ public class TransicaoProibida extends Model implements Serializable {
         return true;
     }
 
+    @AssertTrue(groups = ControladorTransicoesProibidasCheck.class,
+        message = "O estágio de origem deve ser diferente do alternativo se o estágio de destino for demanda prioritária.")
+    public boolean isOrigemDiferenteDeAlternativoSeDestinoEhDemandaPrioritaria() {
+        if (getDestino() != null && getDestino().isDemandaPrioritaria()) {
+            return getOrigem() != getAlternativo();
+        }
+        return true;
+    }
+
     public boolean isDestroy() {
         return destroy;
     }

--- a/influunt-api/test/integracao/BasicMQTTTest.java
+++ b/influunt-api/test/integracao/BasicMQTTTest.java
@@ -94,7 +94,8 @@ public class BasicMQTTTest extends WithInfluuntApplicationNoAuthentication {
         onDisconectFutureList.clear();
         onSubscribeFutureList.clear();
         onPublishFutureList.clear();
-        System.gc();
+//        System.gc();
+        Thread.sleep(100);
     }
 
     protected void setConfig() throws IOException, InterruptedException {

--- a/influunt-api/test/integracao/BasicMQTTTest.java
+++ b/influunt-api/test/integracao/BasicMQTTTest.java
@@ -141,7 +141,7 @@ public class BasicMQTTTest extends WithInfluuntApplicationNoAuthentication {
         mqttBroker.startServer(classPathConfig, userHandlers);
         Thread.sleep(100);
         central = provideApp.injector().instanceOf(Central.class);
-        Thread.sleep(2000);
+        Thread.sleep(1000);
     }
 
     protected void startClient() {

--- a/influunt-api/test/integracao/BasicMQTTTest.java
+++ b/influunt-api/test/integracao/BasicMQTTTest.java
@@ -95,7 +95,11 @@ public class BasicMQTTTest extends WithInfluuntApplicationNoAuthentication {
         onSubscribeFutureList.clear();
         onPublishFutureList.clear();
 //        System.gc();
-        Thread.sleep(100);
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     protected void setConfig() throws IOException, InterruptedException {

--- a/influunt-api/test/integracao/BasicMQTTTest.java
+++ b/influunt-api/test/integracao/BasicMQTTTest.java
@@ -94,12 +94,7 @@ public class BasicMQTTTest extends WithInfluuntApplicationNoAuthentication {
         onDisconectFutureList.clear();
         onSubscribeFutureList.clear();
         onPublishFutureList.clear();
-//        System.gc();
-        try {
-            Thread.sleep(100);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        System.gc();
     }
 
     protected void setConfig() throws IOException, InterruptedException {
@@ -146,10 +141,16 @@ public class BasicMQTTTest extends WithInfluuntApplicationNoAuthentication {
         mqttBroker.startServer(classPathConfig, userHandlers);
         Thread.sleep(100);
         central = provideApp.injector().instanceOf(Central.class);
+        Thread.sleep(2000);
     }
 
     protected void startClient() {
         client = new Client(this.deviceConfig);
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     protected void assertTransacaoOk() {

--- a/influunt-api/test/models/ControladorAssociacoesTest.java
+++ b/influunt-api/test/models/ControladorAssociacoesTest.java
@@ -120,7 +120,7 @@ public class ControladorAssociacoesTest extends ControladorTest {
         erros = getErros(controlador);
         assertEquals(1, erros.size());
         assertThat(erros, Matchers.hasItems(
-            new Erro(CONTROLADOR, "O Tempo de verde do estágio de demanda priortária deve estar entre {min} e {max}", "aneis[1].estagios[0].tempoVerdeDemandaPrioritaria")
+            new Erro(CONTROLADOR, "O Tempo de verde do estágio de demanda prioritária deve estar entre {min} e {max}", "aneis[1].estagios[0].tempoVerdeDemandaPrioritaria")
         ));
 
         estagioNovo.setTempoVerdeDemandaPrioritaria(10);
@@ -134,8 +134,8 @@ public class ControladorAssociacoesTest extends ControladorTest {
             new Erro(CONTROLADOR, "O anel ativo deve ter somente um estágio de demanda prioritária.", "aneis[0].somenteUmEstagioDeDemandaPrioritaria"),
             new Erro(CONTROLADOR, "Esse grupo semafórico não pode estar associado a um estágio de demanda prioritária e a outro estágio ao mesmo tempo.", "aneis[0].gruposSemaforicos[0].naoEstaAssociadoAEstagioDemandaPrioritariaEOutroEstagio"),
             new Erro(CONTROLADOR, "Esse grupo semafórico não pode estar associado a um estágio de demanda prioritária e a outro estágio ao mesmo tempo.", "aneis[0].gruposSemaforicos[1].naoEstaAssociadoAEstagioDemandaPrioritariaEOutroEstagio"),
-            new Erro(CONTROLADOR, "O Tempo de verde do estágio de demanda priortária deve estar entre {min} e {max}", "aneis[0].estagios[0].tempoVerdeDemandaPrioritaria"),
-            new Erro(CONTROLADOR, "O Tempo de verde do estágio de demanda priortária deve estar entre {min} e {max}", "aneis[0].estagios[1].tempoVerdeDemandaPrioritaria"),
+            new Erro(CONTROLADOR, "O Tempo de verde do estágio de demanda prioritária deve estar entre {min} e {max}", "aneis[0].estagios[0].tempoVerdeDemandaPrioritaria"),
+            new Erro(CONTROLADOR, "O Tempo de verde do estágio de demanda prioritária deve estar entre {min} e {max}", "aneis[0].estagios[1].tempoVerdeDemandaPrioritaria"),
             new Erro(CONTROLADOR, "Estágio de demanda prioritária deve ser associado a um grupo semafórico veicular.", "aneis[0].estagios[0].umGrupoSemaforicoVeicularEmDemandaPrioritaria")
         ));
 

--- a/influunt-api/test/models/ControladorTransicoesProibidasTest.java
+++ b/influunt-api/test/models/ControladorTransicoesProibidasTest.java
@@ -108,12 +108,13 @@ public class ControladorTransicoesProibidasTest extends ControladorTest {
 
         erros = getErros(controlador);
 
-        assertEquals(4, erros.size());
+        assertEquals(5, erros.size());
         assertThat(erros, org.hamcrest.Matchers.hasItems(
             new Erro(CONTROLADOR, "O estágio de origem deve ser diferente do estágio de destino.", "aneis[1].estagios[0].origemDeTransicoesProibidas[0].origemEDestinoDiferentes"),
             new Erro(CONTROLADOR, "Esse estágio não pode ter um estágio de destino e alternativo ao mesmo tempo.", "aneis[1].estagios[0].aoMesmoTempoDestinoEAlternativo"),
             new Erro(CONTROLADOR, "O Estágio alternativo deve ser diferente do destino.", "aneis[1].estagios[0].origemDeTransicoesProibidas[0].estagioAlternativoDiferenteOrigemEDestino"),
-            new Erro(CONTROLADOR, "O Estágio de origem não pode ter transição proibida para estágio alternativo.", "aneis[1].estagios[0].origemDeTransicoesProibidas[0].origemNaoPossuiTransicaoProibidaParaAlternativo")
+            new Erro(CONTROLADOR, "O Estágio de origem não pode ter transição proibida para estágio alternativo.", "aneis[1].estagios[0].origemDeTransicoesProibidas[0].origemNaoPossuiTransicaoProibidaParaAlternativo"),
+            new Erro(CONTROLADOR, "O estágio de origem deve ser diferente do alternativo se o estágio de destino for demanda prioritária.", "aneis[1].estagios[0].origemDeTransicoesProibidas[0].origemDiferenteDeAlternativoSeDestinoEhDemandaPrioritaria")
         ));
 
         estagio1AnelCom2Estagios.setDestinoDeTransicoesProibidas(null);
@@ -248,6 +249,38 @@ public class ControladorTransicoesProibidasTest extends ControladorTest {
         transicaoProibida.setOrigem(null);
         transicaoProibida.setDestino(null);
         transicaoProibida.setAlternativo(null);
+
+        erros = getErros(controlador);
+        assertEquals(0, erros.size());
+
+
+        estagio1AnelCom4Estagios.setOrigemDeTransicoesProibidas(null);
+        estagio1AnelCom4Estagios.setDestinoDeTransicoesProibidas(null);
+        estagio1AnelCom4Estagios.setAlternativaDeTransicoesProibidas(null);
+
+        estagio2AnelCom4Estagios.setOrigemDeTransicoesProibidas(null);
+        estagio2AnelCom4Estagios.setDestinoDeTransicoesProibidas(null);
+        estagio2AnelCom4Estagios.setAlternativaDeTransicoesProibidas(null);
+
+        estagio2AnelCom4Estagios.setDemandaPrioritaria(true);
+        estagio2AnelCom4Estagios.setTempoVerdeDemandaPrioritaria(30);
+
+        transicaoProibida.setOrigem(estagio1AnelCom4Estagios);
+        transicaoProibida.setDestino(estagio2AnelCom4Estagios);
+        transicaoProibida.setAlternativo(estagio1AnelCom4Estagios);
+        estagio1AnelCom4Estagios.setOrigemDeTransicoesProibidas(Collections.singletonList(transicaoProibida));
+        estagio2AnelCom4Estagios.setDestinoDeTransicoesProibidas(Collections.singletonList(transicaoProibida));
+        estagio1AnelCom4Estagios.setAlternativaDeTransicoesProibidas(Collections.singletonList(transicaoProibida));
+
+        erros = getErros(controlador);
+        assertEquals(2, erros.size());
+
+        assertThat(erros, org.hamcrest.Matchers.hasItems(
+            new Erro(CONTROLADOR, "O estágio de origem deve ser diferente do alternativo se o estágio de destino for demanda prioritária.", "aneis[0].estagios[0].origemDeTransicoesProibidas[0].origemDiferenteDeAlternativoSeDestinoEhDemandaPrioritaria"),
+            new Erro(CONTROLADOR, "Esse grupo semafórico não pode estar associado a um estágio de demanda prioritária e a outro estágio ao mesmo tempo.", "aneis[0].gruposSemaforicos[1].naoEstaAssociadoAEstagioDemandaPrioritariaEOutroEstagio")
+        ));
+
+        estagio2AnelCom4Estagios.setDemandaPrioritaria(false);
 
         erros = getErros(controlador);
         assertEquals(0, erros.size());


### PR DESCRIPTION
fixes #1499 

Se um estágio de demanda prioritária for destino de uma transição proibida, o estágio de origem não pode ser o estágio alternativo.
