### PR TITLE
hotfixes erro de criacao de agrupamento em mapas

### DIFF
--- a/influunt-app/app/scripts/services/mapa/provider.js
+++ b/influunt-app/app/scripts/services/mapa/provider.js
@@ -219,6 +219,7 @@ var mapProviderObj = function(MAP, $timeout) {
 
     var points = L.LatLng.getLatLng(obj.points);
     points = L.LatLng.orderPoints(points);
+    points = _.compact(points);
     points = L.LatLng.getMiddlePoints(points);
     points = L.LatLng.getBoundingBox(points);
     points = L.LatLng.getHullPoints(points);


### PR DESCRIPTION
Correção de um que ocorria nos mapas ao criar agrupamentos com somente um ponto no mapa.

Agora, o agrupamento não será apresentado (não há agrupamentos com somente um ponto no mapa) e não há mais erro no console.