### PR TITLE
fix erro estagios sem imagem e mapa em popup

### DIFF
--- a/influunt-app/app/scripts/directives/influunt-map.js
+++ b/influunt-app/app/scripts/directives/influunt-map.js
@@ -18,8 +18,8 @@ angular.module('influuntApp')
         onClickMarker: '&?',
         mapId: '=?'
       },
-      link: function(scope, element) {
-        scope.mapId = UUID.generate();
+      link: function(scope, element, attrs) {
+        scope.mapId = attrs.mapaId || UUID.generate();
         var _mapaProvider = mapaProvider.getMap(scope.mapId);
 
         _mapaProvider.initializeMap(element[0], scope.options);

--- a/influunt-app/app/scripts/directives/wizard-footer.js
+++ b/influunt-app/app/scripts/directives/wizard-footer.js
@@ -36,14 +36,14 @@ angular.module('influuntApp')
       }
     };
   }])
-  .directive('popupRevisao', ['mapaProvider', function (mapaProvider) {
+  .directive('popupRevisao', ['mapaProvider', '$timeout', function (mapaProvider, $timeout) {
     return {
       templateUrl: 'views/controladores/wizard/common/popup-revisao.html',
       restrict: 'E',
       link: function(scope, el, attrs) {
         $(document).ready(function() {
           $('#myModal').on('show.bs.modal', function() {
-            setTimeout(function() {
+            $timeout(function() {
               var mapa = mapaProvider.getMap('popup-revisao');
               mapa.resetView();
               mapa.setViewForMarkers();

--- a/influunt-app/app/scripts/directives/wizard-footer.js
+++ b/influunt-app/app/scripts/directives/wizard-footer.js
@@ -23,7 +23,7 @@ angular.module('influuntApp')
         };
 
         scope.translateBotaoSalvar = function(step) {
-          var stepEntreVerdes = "app.wizard_controladores.entre_verdes";
+          var stepEntreVerdes = 'app.wizard_controladores.entre_verdes';
           var botaoEntreVerdes = 'geral.tooltip.naoPodeSalvarSemConfirmacaoEntreVerdes';
           var botaoDefault = 'geral.tooltip.naoPodeSalvarSemConfirmacao';
 
@@ -35,4 +35,22 @@ angular.module('influuntApp')
         };
       }
     };
-  }]);
+  }])
+  .directive('popupRevisao', ['mapaProvider', function (mapaProvider) {
+    return {
+      templateUrl: 'views/controladores/wizard/common/popup-revisao.html',
+      restrict: 'E',
+      link: function(scope, el, attrs) {
+        $(document).ready(function() {
+          $('#myModal').on('show.bs.modal', function() {
+            setTimeout(function() {
+              var mapa = mapaProvider.getMap('popup-revisao');
+              mapa.resetView();
+              mapa.setViewForMarkers();
+            }, 500);
+          });
+        });
+      }
+    };
+  }])
+  ;

--- a/influunt-app/app/scripts/services/mapa/provider.js
+++ b/influunt-app/app/scripts/services/mapa/provider.js
@@ -10,7 +10,7 @@ var mapProviderObj = function(MAP, $timeout) {
   var DEFAULTS = {LATITUDE: -23.550382, LONGITUDE: -46.663956, ZOOM: 15};
 
   // funcoes de mapa.
-  var initializeMap, setView, getMap;
+  var initializeMap, setView, getMap, resetView;
 
   // funcoes de markers.
   var onMarkerClick, setOnMarkerClick;
@@ -239,6 +239,10 @@ var mapProviderObj = function(MAP, $timeout) {
     }
   };
 
+  resetView = function() {
+    map.invalidateSize();
+  };
+
   return {
     initializeMap: initializeMap,
     getMap: getMap,
@@ -247,6 +251,7 @@ var mapProviderObj = function(MAP, $timeout) {
     renderMarkers: renderMarkers,
     renderAreas: renderAreas,
     renderAgrupamentos: renderAgrupamentos,
+    resetView: resetView,
 
     setOnMarkerClick: setOnMarkerClick,
     selectMarkerById: selectMarkerById

--- a/influunt-app/app/views/controladores/wizard/aneis.html
+++ b/influunt-app/app/views/controladores/wizard/aneis.html
@@ -196,6 +196,3 @@
       previous-step="app.wizard_controladores.dados_basicos">
   </wizard-footer>
 </fieldset>
-
-
-<ng-include src="'views/controladores/wizard/common/popup-revisao.html'">

--- a/influunt-app/app/views/controladores/wizard/associacao-detectores.html
+++ b/influunt-app/app/views/controladores/wizard/associacao-detectores.html
@@ -169,5 +169,3 @@
       require-assertion="true">
   </wizard-footer>
 </fieldset>
-
-<ng-include src="'views/controladores/wizard/common/popup-revisao.html'">

--- a/influunt-app/app/views/controladores/wizard/associacao.html
+++ b/influunt-app/app/views/controladores/wizard/associacao.html
@@ -123,5 +123,3 @@
     </wizard-footer>
   </div>
 </fieldset>
-
-<ng-include src="'views/controladores/wizard/common/popup-revisao.html'">

--- a/influunt-app/app/views/controladores/wizard/atraso-de-grupo.html
+++ b/influunt-app/app/views/controladores/wizard/atraso-de-grupo.html
@@ -150,5 +150,3 @@
       require-assertion="true">
   </wizard-footer>
 </fieldset>
-
-<ng-include src="'views/controladores/wizard/common/popup-revisao.html'">

--- a/influunt-app/app/views/controladores/wizard/configuracao-grupo.html
+++ b/influunt-app/app/views/controladores/wizard/configuracao-grupo.html
@@ -135,5 +135,3 @@
     </wizard-footer>
   </div>
 </fieldset>
-
-<ng-include src="'views/controladores/wizard/common/popup-revisao.html'">

--- a/influunt-app/app/views/controladores/wizard/entre-verdes.html
+++ b/influunt-app/app/views/controladores/wizard/entre-verdes.html
@@ -153,5 +153,3 @@
       require-assertion="true">
   </wizard-footer>
 </fieldset>
-
-<ng-include src="'views/controladores/wizard/common/popup-revisao.html'">

--- a/influunt-app/app/views/controladores/wizard/transicoes-proibidas.html
+++ b/influunt-app/app/views/controladores/wizard/transicoes-proibidas.html
@@ -98,5 +98,3 @@
       require-assertion="true">
   </wizard-footer>
 </fieldset>
-
-<ng-include src="'views/controladores/wizard/common/popup-revisao.html'">

--- a/influunt-app/app/views/controladores/wizard/verdes-conflitantes.html
+++ b/influunt-app/app/views/controladores/wizard/verdes-conflitantes.html
@@ -56,5 +56,3 @@
       previous-step="app.wizard_controladores.configuracao_grupo">
   </wizard-footer>
 </fieldset>
-
-<ng-include src="'views/controladores/wizard/common/popup-revisao.html'">

--- a/influunt-app/app/views/directives/influunt-revisao/_dados_basicos.html
+++ b/influunt-app/app/views/directives/influunt-revisao/_dados_basicos.html
@@ -24,6 +24,6 @@
 <div class="col-lg-3 col-sm-6">
   <p><strong>{{ 'controladores.nomeEndereco' | translate }}:</strong> {{ dadosBasicos.endereco }}</p>
   <figure>
-    <div influunt-map markers="markerEnderecoControlador" class="influunt-map"></div>
+    <div influunt-map markers="markerEnderecoControlador" mapa-id="popup-revisao" class="influunt-map"></div>
   </figure>
 </div>

--- a/influunt-app/app/views/directives/wizard-footer.html
+++ b/influunt-app/app/views/directives/wizard-footer.html
@@ -50,3 +50,5 @@
     </div>
   </div>
 </div>
+
+<popup-revisao></popup-revisao>

--- a/influunt-app/test/spec/controllers/controladores/aneis.js
+++ b/influunt-app/test/spec/controllers/controladores/aneis.js
@@ -237,9 +237,7 @@ describe('Controller: ControladoresAneisCtrl', function () {
 
         it('Os estágios sem imagens devem ser removidos da lista de estágios', function () {
           expect(scope.imagensDeEstagios.length).toBe(1);
-          expect(true).toBe(true);
         });
-
       });
 
       describe('Quado o app produz estágios sem imagem', function () {

--- a/influunt-app/test/spec/controllers/controladores/aneis.js
+++ b/influunt-app/test/spec/controllers/controladores/aneis.js
@@ -208,4 +208,71 @@ describe('Controller: ControladoresAneisCtrl', function () {
       expect(scope.objeto.aneis[0].ativo).toBeTruthy();
     });
   });
+
+  describe('bugs', function() {
+    describe('estágios sem imagens', function () {
+      describe('Quando a API retorna um estágio sem imagem', function () {
+        beforeEach(function() {
+          var objeto = {
+            aneis: [
+              {
+                idJson: 'anel-1',
+                ativo: true,
+                endereco: {idJson: 'e3'},
+                estagios: [{idJson: 'e1'}, {idJson: 'e2'}],
+                gruposSemaforicos: [{idJson: 'gs1'}],
+                detectores: [{idJson: 'd1'}],
+                planos: [{idJson: 'p1'}]
+              },
+              {idJson: 'anel-3',ativo: false}
+            ],
+            todosEnderecos: [{idJson: 'e1'},{idJson: 'e2'},{idJson: 'e3'},{idJson: 'e4'}],
+            estagios: [{idJson: 'e1', imagem: { idJson: 'imagem-1'}}, {idJson: 'e2'}],
+            imagens: [{idJson: 'imagem-1'}]
+          };
+
+          WizardControladores.fakeInicializaWizard(scope, $q, objeto, scope.inicializaAneis);
+          scope.$apply();
+        });
+
+        it('Os estágios sem imagens devem ser removidos da lista de estágios', function () {
+          expect(scope.imagensDeEstagios.length).toBe(1);
+          expect(true).toBe(true);
+        });
+
+      });
+
+      describe('Quado o app produz estágios sem imagem', function () {
+        beforeEach(function() {
+          var objeto = {
+            aneis: [
+              {
+                idJson: 'anel-1',
+                ativo: true,
+                endereco: {idJson: 'e3'},
+                estagios: [{idJson: 'e1'}, {idJson: 'e2'}],
+                gruposSemaforicos: [{idJson: 'gs1'}],
+                detectores: [{idJson: 'd1'}],
+                planos: [{idJson: 'p1'}]
+              }
+            ],
+            todosEnderecos: [{idJson: 'e1'},{idJson: 'e2'},{idJson: 'e3'},{idJson: 'e4'}],
+            estagios: [{idJson: 'e1', imagem: { idJson: 'imagem-1'}}, {idJson: 'e2'}],
+            imagens: [{idJson: 'imagem-1'}]
+          };
+
+          WizardControladores.fakeInicializaWizard(scope, $q, objeto, scope.inicializaAneis);
+          scope.$apply();
+        });
+
+        it('Deve remover os estágios sem imagens antes de enviar à API', function () {
+          scope.beforeSubmitForm();
+          scope.$apply();
+
+          expect(scope.objeto.aneis[0].estagios.length).toBe(1);
+          expect(scope.objeto.estagios.length).toBe(1);
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
- Inibe estágios sem imagens na entrada do app, ou seja, quando a API devolve estágios sem imagem associada;
- Inibe estágios sem imagens na saída do app, ou seja, quando o app produz estes estágios, a correção proibe estes estágios serem enviados;
- Corrige um bug existente no mapa do popup de revisão: Mapas do Leaflet têm problemas quando utilizados em popups.

> OBS.: O problema descrito pela Suely se devia aos estágios sem imagens, que foram cadastrados de forma ainda não descoberta. Estes estágios foram removidos manualmente da base (através de chamadas ao endpoint `DELETE => /api/api/v1/estagios/$id<[^/]+>`). Nenhum problema foi detectado até então mas, se for o caso, o banco em estado anterior pode ser restaurado através deste [backup](https://influunt.slack.com/files/ppires/F5ZKQ7P27/influunt-production_2017-06-26.sql.tar.gz).